### PR TITLE
docs: Fix simple typo, inprecision -> imprecision

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ An imaginary number k instance
 
 Quaternion.EPSILON
 ---
-A small epsilon value used for `equals()` comparison in order to circumvent double inprecision.
+A small epsilon value used for `equals()` comparison in order to circumvent double imprecision.
 
 
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `imprecision` rather than `inprecision`.

